### PR TITLE
Major bug fix

### DIFF
--- a/ExtensiveCell/ECViewController.m
+++ b/ExtensiveCell/ECViewController.m
@@ -144,8 +144,14 @@
         
         if (self.selectedRowIndexPath)
         {
-            NSIndexPath *tmpIndexPath = [NSIndexPath indexPathForRow:(indexPath.row - 1) inSection:indexPath.section];
-            cell = [self extensiveCellForRowIndexPath:tmpIndexPath];
+            if ((indexPath.section >= self.selectedRowIndexPath.section) && (indexPath.row > self.selectedRowIndexPath.row)) {
+                NSIndexPath *tmpIndexPath = [NSIndexPath indexPathForRow:(indexPath.row - 1) inSection:indexPath.section];
+                cell = [self extensiveCellForRowIndexPath:tmpIndexPath];
+            }
+            else
+            {
+                cell = [self extensiveCellForRowIndexPath:indexPath];
+            }
         }
         else
         {


### PR DESCRIPTION
This freaking bug tormented me for too long.
it happens when you extend a cell mid table and scroll down then scroll
all the way back up.
The app crashes as the row at index 0 is modified to UINT64_MAX (if using unsigned) which
obviously generates an out-of-bounds error.
The justification to what i've added is that the cells above the extended cell aren't modified so i don't need to subtract 1 of their indexpath.row. This should only be done for the cells below the extended one.
